### PR TITLE
feat(shapes): add translation capability to shapes

### DIFF
--- a/src/shapes/AShape.hpp
+++ b/src/shapes/AShape.hpp
@@ -14,6 +14,8 @@ namespace Raytracer {
           const Raytracer::Ray &ray) const = 0;
 
       virtual Math::Vector3D getNormal(const Math::Point3D &hitPoint) const = 0;
+
+      virtual void translate(const Math::Vector3D &offset) = 0;
   };
 
 }  // namespace Raytracer

--- a/src/shapes/IShape.hpp
+++ b/src/shapes/IShape.hpp
@@ -13,6 +13,8 @@ namespace Raytracer {
           const Raytracer::Ray &ray) const = 0;
 
       virtual Math::Vector3D getNormal(const Math::Point3D &hitPoint) const = 0;
+
+      virtual void translate(const Math::Vector3D &offset) = 0;
   };
 
 }  // namespace Raytracer

--- a/src/shapes/Plane.hpp
+++ b/src/shapes/Plane.hpp
@@ -28,6 +28,10 @@ namespace Raytracer {
         return _normal;
       }
 
+      void translate(const Math::Vector3D &offset) override {
+        _center = _center + offset;
+      }
+
     private:
       Math::Point3D _center;
       Math::Vector3D _normal;

--- a/src/shapes/ShapeComposite.hpp
+++ b/src/shapes/ShapeComposite.hpp
@@ -21,6 +21,11 @@ namespace Raytracer {
         return Math::Vector3D(0, 0, 0);
       }
 
+      void translate(const Math::Vector3D &offset) override {
+        for (const auto &shape : shapes)
+          shape->translate(offset);
+      }
+
     private:
       std::vector<std::shared_ptr<IShape>> shapes;
   };

--- a/src/shapes/Sphere.hpp
+++ b/src/shapes/Sphere.hpp
@@ -29,6 +29,10 @@ namespace Raytracer {
         return (point - _center).normalize();
       }
 
+      void translate(const Math::Vector3D &offset) override {
+        _center = _center + offset;
+      }
+
     private:
       Math::Point3D _center;
       Math::Vector3D _color;


### PR DESCRIPTION
Add translate method to shape interfaces and implementations to support moving shapes by a vector offset. Implemented in:
- Sphere
- Plane
- ShapeComposite (which translates all contained shapes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d'une méthode de translation pour les formes, permettant de déplacer des plans, sphères et groupes de formes dans l'espace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->