### PR TITLE
refactor(shapes): move common members to AShape base class

### DIFF
--- a/src/shapes/AShape.hpp
+++ b/src/shapes/AShape.hpp
@@ -15,7 +15,13 @@ namespace Raytracer {
 
       virtual Math::Vector3D getNormal(const Math::Point3D &hitPoint) const = 0;
 
-      virtual void translate(const Math::Vector3D &offset) = 0;
+      virtual void translate(const Math::Vector3D &offset) {
+        _center = _center + offset;
+      }
+
+    protected:
+      Math::Point3D _center;
+      Math::Vector3D _color;
   };
 
 }  // namespace Raytracer

--- a/src/shapes/Plane.hpp
+++ b/src/shapes/Plane.hpp
@@ -9,13 +9,14 @@ namespace Raytracer {
     public:
       Plane(const Math::Point3D &center, const Math::Vector3D &normal,
             const Math::Vector3D &color)
-          : _center(center), _normal(normal), _color(color) {
+          : _normal(normal) {
+        _center = center;
+        _color = color;
       }
 
-      Plane()
-          : _center(Math::Point3D()),
-            _normal(Math::Vector3D()),
-            _color(Math::Vector3D(1, 0, 0)) {
+      Plane() : _normal(Math::Vector3D()) {
+        _center = Math::Point3D();
+        _color = Math::Vector3D(1, 0, 0);
       }
 
       ~Plane() = default;
@@ -28,14 +29,8 @@ namespace Raytracer {
         return _normal;
       }
 
-      void translate(const Math::Vector3D &offset) override {
-        _center = _center + offset;
-      }
-
     private:
-      Math::Point3D _center;
       Math::Vector3D _normal;
-      Math::Vector3D _color;
   };
 
 }  // namespace Raytracer

--- a/src/shapes/Sphere.hpp
+++ b/src/shapes/Sphere.hpp
@@ -11,13 +11,14 @@ namespace Raytracer {
     public:
       Sphere(const Math::Point3D &center, double radius,
              const Math::Vector3D &color)
-          : _center(center), _color(color), _radius(radius) {
+          : _radius(radius) {
+        _center = center;
+        _color = color;
       }
 
-      Sphere()
-          : _center(Math::Point3D(0, 0, 0)),
-            _color(Math::Vector3D(1, 0, 0)),
-            _radius(1) {
+      Sphere() : _radius(1) {
+        _center = Math::Point3D(0, 0, 0);
+        _color = Math::Vector3D(1, 0, 0);
       }
 
       ~Sphere() = default;
@@ -29,13 +30,7 @@ namespace Raytracer {
         return (point - _center).normalize();
       }
 
-      void translate(const Math::Vector3D &offset) override {
-        _center = _center + offset;
-      }
-
     private:
-      Math::Point3D _center;
-      Math::Vector3D _color;
       double _radius;
   };
 


### PR DESCRIPTION
- Moved _center and _color members from derived shape classes to AShape
- Implemented default translate method in the base class
- Updated shape class constructors to properly initialize base members

This change reduces code duplication and follows the DRY principle by centralizing common shape attributes in the abstract base class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’un comportement par défaut pour le déplacement des formes, permettant de déplacer le centre d’une forme avec un vecteur de translation.
- **Refactorisation**
  - Centralisation de la gestion de la position et de la couleur dans la classe de base des formes.
  - Simplification des classes Plane et Sphere en retirant la duplication des attributs de position et de couleur, ainsi que leurs méthodes de translation spécifiques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->