### PR TITLE
fix(shapes): improve plane intersection calculation

### DIFF
--- a/src/shapes/Plane.cpp
+++ b/src/shapes/Plane.cpp
@@ -20,12 +20,10 @@ std::tuple<double, Math::Vector3D, const Raytracer::IShape *>
 Raytracer::Plane::hits(const Raytracer::Ray &ray) const {
   float denominator = _normal.dot(ray.direction);
 
-  if (denominator == 0) {
-    return {0.0, _color, this};
+  if (std::abs(denominator) > 1e-6) {
+    Math::Vector3D vectorToPlane = _center - ray.origin;
+    float t = vectorToPlane.dot(_normal) / denominator;
+    return {t, _color, this};
   }
-  float t = (ray.origin - _center).dot(_normal) / denominator;
-  if (t < 0) {
-    return {0.0, _color, this};
-  }
-  return {t, _color, this};
+  return {0.0, _color, nullptr};
 }


### PR DESCRIPTION
- Add epsilon check for parallel ray detection
- Use more numerically stable ray-plane intersection formula
- Return proper null result when no intersection occurs
- Fix edge cases in ray-plane intersection logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Corrections de bugs**
  - Correction de la détection d’intersection entre un rayon et un plan : les rayons parallèles au plan ne sont plus considérés comme des intersections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->