### PR TITLE
feat(renderer): implement block rendering for better performance

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -49,7 +49,12 @@ void Raytracer::Renderer::renderToBuffer(std::vector<sf::Color> &framebuffer,
       sf::Color pixel_color(static_cast<sf::Uint8>(color.x * 255),
                             static_cast<sf::Uint8>(color.y * 255),
                             static_cast<sf::Uint8>(color.z * 255));
-      framebuffer[j * _width + i] = pixel_color;
+      int endY = j + step;
+      int endX = i + step;
+      for (int blockY = j; blockY < endY; blockY++) {
+        for (int blockX = i; blockX < endX; blockX++)
+          framebuffer[blockY * _width + blockX] = pixel_color;
+      }
     }
   }
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -104,6 +104,7 @@ void Raytracer::Scene::render() {
         _window.close();
     }
     changeCamQuality();
+    std::fill(_framebuffer.begin(), _framebuffer.end(), sf::Color::White);
     renderer.renderToBuffer(_framebuffer, cam, _isHighQuality);
     updateImage();
     _window.clear(sf::Color::White);


### PR DESCRIPTION
- Add step-based block rendering that fills multiple pixels with the same color
- Initialize the framebuffer with white before rendering to ensure clean state