### PR TITLE
fix: loader, remove gitkeep error

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -94,6 +94,8 @@ void Raytracer::Scene::parsePlugins() {
   for (const auto &entry : std::filesystem::directory_iterator("./plugins")) {
     if (entry.path().extension() == ".so")
       _plugins.push_back(entry.path().string());
+    else
+     continue;
     void *handler = dlopen(entry.path().c_str(), RTLD_LAZY);
     if (!handler) {
       std::cerr << "[ERROR] - Failed to load plugin: " << entry.path()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Corrections de bugs**
  - Amélioration du chargement des plugins : seuls les fichiers avec l’extension `.so` sont désormais traités, évitant ainsi les tentatives de chargement de fichiers non compatibles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->