### PR TITLE
Fix compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "extern/googletest"]
-	path = extern/googletest
-	url = https://github.com/google/googletest.git
-	branch = v1.14.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "extern/googletest"]
+	path = extern/googletest
+	url = https://github.com/google/googletest.git
+	branch = v1.14.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,23 @@ if(ENABLE_TESTS)
       $<TARGET_OBJECTS:math_objects>
     )
 
+    add_dependencies(unit_tests
+      sphere
+      plane
+      cylinder
+      cylinderInf
+      cone
+      coneInf
+      object
+      triangle
+      directional
+      ambient
+      point
+      reflection
+      refraction
+      transparent
+    )
+
     add_custom_command(TARGET unit_tests PRE_BUILD
       COMMAND find ${CMAKE_BINARY_DIR}/CMakeFiles -name '*.gcda' -delete
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,13 +320,7 @@ if(BUILD_TESTING)
       add_link_options(--coverage)
     endif()
 
-    include(FetchContent)
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG v1.17.0
-    )
-    FetchContent_MakeAvailable(googletest)
+    add_subdirectory(extern/googletest)
 
     file(COPY tests/ DESTINATION ${CMAKE_BINARY_DIR}/tests)
     file(COPY ${CMAKE_SOURCE_DIR}/plugins DESTINATION ${CMAKE_BINARY_DIR}/plugins)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,13 +309,13 @@ execute_process(
 )
 
 # Unit tests configuration
-option(BUILD_TESTING "Build the tests" ON)
+option(ENABLE_TESTS "Build the tests" OFF)
 
-if(BUILD_TESTING)
+if(ENABLE_TESTS)
     set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
     enable_testing()
 
-    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND BUILD_TESTING)
+    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ENABLE_TESTS)
       add_compile_options(--coverage)
       add_link_options(--coverage)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,13 @@ if(BUILD_TESTING)
       add_link_options(--coverage)
     endif()
 
-    add_subdirectory(extern/googletest)
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG v1.17.0
+    )
+    FetchContent_MakeAvailable(googletest)
 
     file(COPY tests/ DESTINATION ${CMAKE_BINARY_DIR}/tests)
     file(COPY ${CMAKE_SOURCE_DIR}/plugins DESTINATION ${CMAKE_BINARY_DIR}/plugins)

--- a/tests/primitives/parsePrimitives.cfg
+++ b/tests/primitives/parsePrimitives.cfg
@@ -30,6 +30,11 @@ primitives :
         g = 0.0;
         b = 1.0;
       };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
+      };
     }
   );
 
@@ -45,6 +50,19 @@ primitives :
         g = 1.0;
         b = 0.0;
       };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
+      };
+      rotate = {
+        axis = {
+          x = 1.0;
+          y = 0.0;
+          z = 0.0;
+          };
+        angle = 45.0;
+      };
     }
   );
 
@@ -58,6 +76,11 @@ primitives :
         r = 1.0;
         g = 1.0;
         b = 0.0;
+      };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
       };
     }
   );
@@ -74,6 +97,19 @@ primitives :
         g = 0.0;
         b = 1.0;
       };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
+      };
+      rotate = {
+        axis = {
+          x = 1.0;
+          y = 0.0;
+          z = 0.0;
+          };
+        angle = 45.0;
+      };
     }
   );
 
@@ -88,6 +124,11 @@ primitives :
         g = 1.0;
         b = 0.0;
       };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
+      };
     }
   );
 
@@ -99,6 +140,11 @@ primitives :
         r = 0.5;
         g = 0.5;
         b = 0.5;
+      };
+      translate = {
+        x = 0.0;
+        y = 0.0;
+        z = -1.0;
       };
     }
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changements de configuration**
  - L’option de compilation des tests a été renommée de `BUILD_TESTING` (activée par défaut) à `ENABLE_TESTS` (désactivée par défaut).
  - Les dépendances des tests unitaires ont été précisées pour garantir la construction préalable des bibliothèques partagées nécessaires.

- **Mise à jour des fichiers de configuration**
  - Ajout de blocs de translation et de rotation explicites dans la configuration des primitives pour définir leurs transformations spatiales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->